### PR TITLE
use tink_syntaxhub to allow pure .kiss class definitions

### DIFF
--- a/kiss/extraParams.hxml
+++ b/kiss/extraParams.hxml
@@ -1,0 +1,1 @@
+--macro kiss.Kiss.setup()

--- a/kiss/src/kiss/Kiss.hx
+++ b/kiss/src/kiss/Kiss.hx
@@ -68,9 +68,12 @@ typedef KissState = {
 
 class Kiss {
     #if macro
-    public static function defaultKissState():KissState {
-        var className = Context.getLocalClass().get().name;
-
+    public static function defaultKissState(?name):KissState {
+        var className = if(name == null){
+            Context.getLocalClass().get().name;
+        }else{
+            name;
+        }
         var k = {
             className: className,
             file: "",
@@ -273,7 +276,7 @@ class Kiss {
     /**
         Build macro: add fields to a class from a corresponding .kiss file
     **/
-    public static function build(?kissFile:String, ?k:KissState, useClassFields = true):Array<Field> {
+    public static function build(?kissFile:String, ?k:KissState, useClassFields = true, ?className:String):Array<Field> {
 
         var classPath = Context.getPosInfos(Context.currentPos()).file;
         // (load... ) relative to the original file
@@ -289,7 +292,7 @@ class Kiss {
                 trace(kissFile);
             #end
                 if (k == null)
-                    k = defaultKissState();
+                    k = defaultKissState(className);
 
                 if (useClassFields) {
                     k.fieldList = Context.getBuildFields();

--- a/kiss/src/kiss/KissFrontend.hx
+++ b/kiss/src/kiss/KissFrontend.hx
@@ -17,7 +17,7 @@ class KissFrontend implements FrontendPlugin {
 		
 		final fields 		= Kiss.build(file,null,false,context.name);
 		var pos 				= Context.makePosition({ file: file, min: 0, max: 999 });
-		trace(context.name);
+		#if debug trace(context.name); #end 
 		final type 			= context.getType();
 											context.addImport('kiss.Prelude',INormal,pos);
 		for (field in fields){

--- a/kiss/src/kiss/KissFrontend.hx
+++ b/kiss/src/kiss/KissFrontend.hx
@@ -1,4 +1,4 @@
-package;
+package kiss;
 
 import kiss.Kiss;
 import tink.syntaxhub.*;

--- a/projects/smooch/README.md
+++ b/projects/smooch/README.md
@@ -1,0 +1,15 @@
+`Context` doesn't have a local type building this way, so you'll have to pass the name from the `FrontendContext` instance to the `defaultKissState` function.
+
+the `--macro KissFrontend.use()` declaration should be in a file called `extraParams.hxml` in the folder with `haxelib.json` and is automatically loaded by haxelib with `-lib kiss`. Seeing as you're not using it, `--macro kiss.Kiss.setup()` should probably go in there.`
+
+This should be enough to build a `*.kiss` file anytime the compiler goes looking for an unknown type.
+
+Imports are handled in the Frontend via `context.addImport`, where the `ImportMode` is
+
+```haxe
+enum ImportMode {
+	INormal;//Represents a default import `import c`.
+	IAsName(alias:String);//Represents the alias import `import c as alias`.
+	IAll;//Represents the wildcard import `import *`.
+}
+```

--- a/projects/smooch/build.hxml
+++ b/projects/smooch/build.hxml
@@ -1,7 +1,7 @@
 -lib kiss
 -cp src
 --macro kiss.Kiss.setup()
---macro KissFrontend.use()
+--macro kiss.KissFrontend.use()
 -lib tink_syntaxhub
 --main smooch.Main
 --interp

--- a/projects/smooch/build.hxml
+++ b/projects/smooch/build.hxml
@@ -1,0 +1,8 @@
+-lib kiss
+-cp src
+--macro kiss.Kiss.setup()
+--macro KissFrontend.use()
+-lib tink_syntaxhub
+--main smooch.Main
+--interp
+

--- a/projects/smooch/haxelib.json
+++ b/projects/smooch/haxelib.json
@@ -1,0 +1,17 @@
+{
+	"main": "smooch.Main",
+	"name": "smooch",
+	"description": "auto build kiss scripts",
+	"classPath": "src/",
+	"dependencies": {
+		"kiss": ""
+	},
+	"url": "https://github.com/NQNStudios/kisslang",
+	"contributors": [
+		"NQNStudios"
+	],
+	"version": "0.0.0",
+	"releasenote": "",
+	"tags": [],
+	"license": "LGPL"
+}

--- a/projects/smooch/haxelib.json
+++ b/projects/smooch/haxelib.json
@@ -4,7 +4,8 @@
 	"description": "auto build kiss scripts",
 	"classPath": "src/",
 	"dependencies": {
-		"kiss": ""
+		"kiss": "",
+		"tink_syntaxhub"
 	},
 	"url": "https://github.com/NQNStudios/kisslang",
 	"contributors": [

--- a/projects/smooch/haxelib.json
+++ b/projects/smooch/haxelib.json
@@ -5,7 +5,7 @@
 	"classPath": "src/",
 	"dependencies": {
 		"kiss": "",
-		"tink_syntaxhub"
+		"tink_syntaxhub" : ""
 	},
 	"url": "https://github.com/NQNStudios/kisslang",
 	"contributors": [

--- a/projects/smooch/src/KissFrontend.hx
+++ b/projects/smooch/src/KissFrontend.hx
@@ -1,0 +1,29 @@
+package;
+
+import kiss.Kiss;
+import tink.syntaxhub.*;
+import haxe.macro.Expr;
+import haxe.macro.Context;
+import haxe.macro.Expr.ImportMode;
+
+class KissFrontend implements FrontendPlugin {
+	
+	public function new() {}
+	
+	public function extensions() 
+		return ['kiss'].iterator();
+	
+	public function parse(file:String, context:FrontendContext):Void {
+		
+		final fields 		= Kiss.build(file,null,false,context.name);
+		var pos 				= Context.makePosition({ file: file, min: 0, max: 999 });
+		trace(context.name);
+		final type 			= context.getType();
+											context.addImport('kiss.Prelude',INormal,pos);
+		for (field in fields){
+			type.fields.push(field);
+		}
+	}
+	static function use()
+		tink.SyntaxHub.frontends.whenever(new KissFrontend());
+}

--- a/projects/smooch/src/LeetCode.kiss
+++ b/projects/smooch/src/LeetCode.kiss
@@ -1,0 +1,15 @@
+// solution to: https://leetcode.com/problems/two-sum-ii-input-array-is-sorted/
+  (function :Array<Int> twosum [:Array<Int> numbers target]
+     (let [di (new Map<Int,Int>)]
+         (doFor [i num] (enumerate numbers 1)
+          //  (print "$i $num")
+             (if (di.exists (- target num))
+             (return [(dictGet di (- target num)) i]))
+            (dictSet di num i)))
+  (return null))
+
+(assert (= (.toString [2 3]) (.toString (twosum [1 2 3 4 5 6] 5))))
+(assert (= (.toString [1 2]) (.toString (twosum [2 7 11 15] 9))))
+(assert (= (.toString [1 3]) (.toString (twosum [2 3 4] 6))))
+(assert (= (.toString [1 2]) (.toString (twosum [-1 0] -1))))
+(trace "here")

--- a/projects/smooch/src/smooch/Main.hx
+++ b/projects/smooch/src/smooch/Main.hx
@@ -1,0 +1,10 @@
+package smooch;
+
+import LeetCode;
+
+class Main{
+  static public function main(){
+    trace('main');
+    @:privateAccess LeetCode.main();
+  }
+}

--- a/projects/smooch/test.sh
+++ b/projects/smooch/test.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+haxe build.hxml


### PR DESCRIPTION
```
export KISS_PROJECT=smooch
./test_project.sh
```
Should run the `LeetCode.kiss` main function